### PR TITLE
Allow for hooks to be installed anywhere.

### DIFF
--- a/hooks/commit-msg.sh
+++ b/hooks/commit-msg.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
-source "$HOME/.hooks/helper.sh"
+SCRIPT_PATH="$0"
+while [ -h "$SCRIPT_PATH" ]; do SCRIPT_PATH=`readlink "$SCRIPT_PATH"`; done
+source "$(dirname $SCRIPT_PATH)/../helper.sh"
 
 HOOK_ERROR=0
 MESSAGE=$(cat $1)

--- a/hooks/pre-commit.sh
+++ b/hooks/pre-commit.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
-source "$HOME/.hooks/helper.sh"
+SCRIPT_PATH="$0"
+while [ -h "$SCRIPT_PATH" ]; do SCRIPT_PATH=`readlink "$SCRIPT_PATH"`; done
+source "$(dirname $SCRIPT_PATH)/../helper.sh"
 
 HOOK_ERROR=0
 


### PR DESCRIPTION
Each hook follows itself to the source file of the symlink. Since the original hooks are contained within git-hooks, we now have the base dir.
