### PR TITLE
Increase shell compatibility

### DIFF
--- a/helper.sh
+++ b/helper.sh
@@ -11,7 +11,7 @@ CROSS=`printf ${RED}'✘'${WHITE}`
 # Char art
 HR=\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#
 
-function helloworld {
+helloworld() {
     echo "usage: git timetrack command [options]"
     echo ""
     echo "    -s, --start           start/continue counting time spent"
@@ -23,37 +23,37 @@ function helloworld {
     echo "    addhook               adds commit-msg hook to the project"
 }
 
-function base_dir {
+base_dir() {
 	echo "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/"
 }
 
-function hooks_dir {
+hooks_dir() {
 	echo "$(base_dir)hooks/"
 }
 
-function modules_dir {
+modules_dir() {
 	echo "$(base_dir)hooks/modules/"
 }
 
-function addons_dir {
+addons_dir() {
 	echo "$(base_dir)hooks/modules/"
 }
 
-function h1() {
+h1() {
 	echo "\n${WHITE}$1 ...\n"
 }
 
-function fail() {
+fail() {
 	echo "\t"${CROSS} ${GREY}$1${WHITE}
 }
 
-function ok() {
+ok() {
 	echo "\t"${CHECK} ${GREY}$1${WHITE}
 }
 
 # Function to get a list of files that will be committed by extension
 # you can for example do "$(commit_files js css)" to get a list of js and css files that wil lbe commited
-function commit_files() {
+commit_files() {
 	
 	if [ $# -eq 0 ] ; then
 	    echo $(git diff-index --name-only --diff-filter=ACM --cached HEAD --)
@@ -69,9 +69,9 @@ function commit_files() {
 	echo $(git diff-index --name-only --diff-filter=ACM --cached HEAD -- | grep -P "$regex")
 }
 
-function count_commit_files() {
+count_commit_files() {
 	echo $(commit_files $@) | wc -w | tr -d ' '
 }
 
 # Load config
-source $(base_dir)config.sh
+. $(base_dir)config.sh

--- a/hooks/commit-msg.sh
+++ b/hooks/commit-msg.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-source "$HOME/.hooks/helper.sh"
+. "$HOME/.hooks/helper.sh"
 
 HOOK_ERROR=0
 MESSAGE=$(cat $1)

--- a/hooks/pre-commit.sh
+++ b/hooks/pre-commit.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-source "$HOME/.hooks/helper.sh"
+. "$HOME/.hooks/helper.sh"
 
 HOOK_ERROR=0
 
@@ -8,7 +8,7 @@ echo ${WHITE}
 for module in $pre_commit_modules; do
     module_path="$(modules_dir)$module"
     [ ! -e $module_path ] && continue
-    source "$(modules_dir)$module"
+    . "$(modules_dir)$module"
     if [ $? -eq 1 ] ; then
         HOOK_ERROR=1
     fi

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-source "helper.sh"
+. "helper.sh"
 
 TMP_DIR=`mktemp -d /tmp/sitebase.hooks.XXXXXXXXXX`
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"


### PR DESCRIPTION
- replace source with . which is recognized by more shells
- replace function syntax with a more generic one

The new syntax works on Debian/Ubuntu default shell dash as well as on bash
